### PR TITLE
Dependencies, GPU and Early Stopping

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
+torch==2.1.0
+matplotlib==3.7.3
 squidpy==1.3.0
 torch_geometric==2.3.1
 scikit-learn==1.3.1
-torch==2.1.0
 louvain==0.8.1
 umap-learn==0.5.4
 torch-scatter==2.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,4 @@ louvain==0.8.1
 umap-learn==0.5.4
 torch-scatter==2.1.2
 pandas==1.5.3 
-statannotations==0.6.0
-seaborn==0.11.2
+seaborn==0.12.2


### PR DESCRIPTION
- Changed torch and matplotlib versions/dependencies
- Changed seaborn version from 0.11.2 to 0.12.2 for 
`OptionError: "No such keys(s): 'mode.use_inf_as_null'"`
  Dependencies conflict between statannotations 0.6.0 and seaborn 0.12.2
- Added the possibility of training with gpu with the device parameter in the _init_ function
- Added the possibility to convert csr_matrix (sparse scipy matrices) into arrays before the training process for torch
- Added patience and early stopping in the code